### PR TITLE
feat(oidc_bootstrap): add policy scope to authenticate on MinIO module

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -266,10 +266,10 @@ Description: Credentials for the administrator user of the master realm created 
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -266,10 +266,10 @@ Description: Credentials for the administrator user of the master realm created 
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
 |===
 

--- a/oidc_bootstrap/README.adoc
+++ b/oidc_bootstrap/README.adoc
@@ -87,7 +87,7 @@ module "oidc" {
 
 NOTE: All the fields on each user are required. Besides, since the e-mail is a scope required by most of our apps, the e-mail is automatically set as verified when the users are created.
 
-IMPORTANT: All users will belong to the administrators group and will have high privileges in applications such as Argo CD.
+IMPORTANT: All users will belong to the administrators group and will have high privileges in applications such as Argo CD and MinIO.
 
 The module contains an output called `devops_stack_users_passwords` where you can get a map containing every username and their respective initial password.
 

--- a/oidc_bootstrap/README.adoc
+++ b/oidc_bootstrap/README.adoc
@@ -174,8 +174,10 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/group[keycloak_group.devops_stack_admins] (resource)
 - https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client[keycloak_openid_client.devops_stack] (resource)
 - https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_default_scopes[keycloak_openid_client_default_scopes.client_default_scopes] (resource)
-- https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_scope[keycloak_openid_client_scope.devops_stack] (resource)
-- https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_group_membership_protocol_mapper[keycloak_openid_group_membership_protocol_mapper.devops_stack] (resource)
+- https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_scope[keycloak_openid_client_scope.devops_stack_groups] (resource)
+- https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_scope[keycloak_openid_client_scope.devops_stack_minio_policy] (resource)
+- https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_group_membership_protocol_mapper[keycloak_openid_group_membership_protocol_mapper.devops_stack_groups] (resource)
+- https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_user_attribute_protocol_mapper[keycloak_openid_user_attribute_protocol_mapper.devops_stack_minio_policy] (resource)
 - https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/realm[keycloak_realm.devops_stack] (resource)
 - https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/user[keycloak_user.devops_stack_users] (resource)
 - https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/user_groups[keycloak_user_groups.devops_stack_admins] (resource)
@@ -300,9 +302,9 @@ Description: Map containing the credentials of each created user.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -313,8 +315,10 @@ Description: Map containing the credentials of each created user.
 |https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/group[keycloak_group.devops_stack_admins] |resource
 |https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client[keycloak_openid_client.devops_stack] |resource
 |https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_default_scopes[keycloak_openid_client_default_scopes.client_default_scopes] |resource
-|https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_scope[keycloak_openid_client_scope.devops_stack] |resource
-|https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_group_membership_protocol_mapper[keycloak_openid_group_membership_protocol_mapper.devops_stack] |resource
+|https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_scope[keycloak_openid_client_scope.devops_stack_groups] |resource
+|https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_client_scope[keycloak_openid_client_scope.devops_stack_minio_policy] |resource
+|https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_group_membership_protocol_mapper[keycloak_openid_group_membership_protocol_mapper.devops_stack_groups] |resource
+|https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/openid_user_attribute_protocol_mapper[keycloak_openid_user_attribute_protocol_mapper.devops_stack_minio_policy] |resource
 |https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/realm[keycloak_realm.devops_stack] |resource
 |https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/user[keycloak_user.devops_stack_users] |resource
 |https://registry.terraform.io/providers/mrparkers/keycloak/latest/docs/resources/user_groups[keycloak_user_groups.devops_stack_admins] |resource

--- a/oidc_bootstrap/README.adoc
+++ b/oidc_bootstrap/README.adoc
@@ -163,9 +163,9 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
-- [[provider_keycloak]] <<provider_keycloak,keycloak>> (>= 4)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_keycloak]] <<provider_keycloak,keycloak>> (>= 4)
 
 === Resources
 
@@ -302,9 +302,9 @@ Description: Map containing the credentials of each created user.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
+|[[provider_random]] <<provider_random,random>> |>= 3
 |===
 
 = Resources

--- a/oidc_bootstrap/locals.tf
+++ b/oidc_bootstrap/locals.tf
@@ -6,7 +6,7 @@ locals {
     api_url       = format("https://keycloak.apps.%s.%s/realms/devops-stack/protocol/openid-connect/userinfo", var.cluster_name, var.base_domain)
     client_id     = "devops-stack-applications"
     client_secret = resource.random_password.client_secret.result
-    oauth2_proxy_extra_args = var.cluster_issuer == "ca-issuer" ? [
+    oauth2_proxy_extra_args = var.cluster_issuer == "ca-issuer" || var.cluster_issuer == "letsencrypt-staging" ? [
       "--insecure-oidc-skip-issuer-verification=true",
       "--ssl-insecure-skip-verify=true",
     ] : []

--- a/oidc_bootstrap/main.tf
+++ b/oidc_bootstrap/main.tf
@@ -35,19 +35,39 @@ resource "keycloak_openid_client" "devops_stack" {
   valid_redirect_uris          = var.oidc_redirect_uris
 }
 
-resource "keycloak_openid_client_scope" "devops_stack" {
+resource "keycloak_openid_client_scope" "devops_stack_groups" {
   realm_id               = resource.keycloak_realm.devops_stack.id
   name                   = "groups"
   description            = "OpenID Connect scope to map a user's group memberships to a claim"
   include_in_token_scope = true
 }
 
-resource "keycloak_openid_group_membership_protocol_mapper" "devops_stack" {
+resource "keycloak_openid_client_scope" "devops_stack_minio_policy" {
+  realm_id               = resource.keycloak_realm.devops_stack.id
+  name                   = "minio-policy"
+  description            = "OpenID Connect scope to map MinIO access policy to a claim"
+  include_in_token_scope = true
+}
+
+resource "keycloak_openid_group_membership_protocol_mapper" "devops_stack_groups" {
   realm_id        = resource.keycloak_realm.devops_stack.id
-  client_scope_id = resource.keycloak_openid_client_scope.devops_stack.id
+  client_scope_id = resource.keycloak_openid_client_scope.devops_stack_groups.id
   name            = "groups"
   claim_name      = "groups"
   full_path       = false
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "devops_stack_minio_policy" {
+  realm_id             = resource.keycloak_realm.devops_stack.id
+  client_scope_id      = resource.keycloak_openid_client_scope.devops_stack_minio_policy.id
+  name                 = "minio-policy"
+  user_attribute       = "policy"
+  claim_name           = "policy"
+  full_path            = false
+  multivalued          = true
+  aggregate_attributes = true
+  add_to_id_token      = true
+  claim_value_type     = "String"
 }
 
 resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
@@ -57,13 +77,18 @@ resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
     "profile",
     "email",
     "roles",
-    resource.keycloak_openid_client_scope.devops_stack.name,
+    resource.keycloak_openid_client_scope.devops_stack_groups.name,
+    resource.keycloak_openid_client_scope.devops_stack_minio_policy.name,
   ]
 }
 
 resource "keycloak_group" "devops_stack_admins" {
   realm_id = resource.keycloak_realm.devops_stack.id
   name     = "devops-stack-admins"
+  attributes = {
+    "terraform" = "true"
+    "policy"    = "consoleAdmin##readwrite##diagnostics"
+  }
 }
 
 resource "random_password" "devops_stack_users" {
@@ -86,7 +111,7 @@ resource "keycloak_user" "devops_stack_users" {
   email          = each.value.email
   email_verified = true
   attributes = {
-    terraform = "true"
+    "terraform" = "true"
   }
 }
 

--- a/oidc_bootstrap/main.tf
+++ b/oidc_bootstrap/main.tf
@@ -63,7 +63,6 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "devops_stack_minio_po
   name                 = "minio-policy"
   user_attribute       = "policy"
   claim_name           = "policy"
-  full_path            = false
   multivalued          = true
   aggregate_attributes = true
   add_to_id_token      = true


### PR DESCRIPTION
## Description of the changes

I added multiple resources on the OIDC bootstrap submodule in order to be able to use the Keycloak users to authenticate in the MinIO web interface and perform administrative tasks without the need to use the root user.

This is accomplished by adding an attribute to the `devops-stack-admins` group that lists the required permissions. Then, this attribute is mapped to a scope that will be passed on the JWT token on authentication to signal MinIO to give the required permissions.

The documentation required is [here](https://min.io/docs/minio/linux/operations/external-iam/configure-keycloak-identity-management.html).

Note that this PR goes hand-in-hand with the following PR on the MinIO module: https://github.com/camptocamp/devops-stack-module-minio/pull/23

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD