### PR TITLE
fix: readd support to deactivate auto-sync which was broken by #20

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,8 +99,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
@@ -108,6 +106,8 @@ The following providers are used by this module:
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -157,7 +157,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.1.1"`
+Default: `"v2.0.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -268,11 +268,11 @@ Description: Credentials for the administrator user of the master realm created 
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |>= 2
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -317,7 +317,7 @@ Description: Credentials for the administrator user of the master realm created 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.1.1"`
+|`"v2.0.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/main.tf
+++ b/main.tf
@@ -63,10 +63,13 @@ resource "argocd_application" "operator" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {
@@ -120,10 +123,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
       retry {
         backoff {

--- a/oidc_bootstrap/README.adoc
+++ b/oidc_bootstrap/README.adoc
@@ -161,11 +161,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_keycloak]] <<provider_keycloak,keycloak>> (>= 4)
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -302,8 +302,8 @@ Description: Map containing the credentials of each created user.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
 |[[provider_null]] <<provider_null,null>> |>= 3
 |===
 


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #20. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)
- [x] KinD