### PR TITLE
 fix!: change the default cluster issuer, remove the namespace variable and hardcode the Helm release name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,8 +99,6 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
@@ -108,6 +106,8 @@ The following providers are used by this module:
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (>= 2)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -143,14 +143,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
-Default: `"argocd"`
-
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -181,7 +173,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.1"`
+Default: `"v2.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -189,15 +181,7 @@ Description: SSL certificate issuer to use. Usually you would configure this val
 
 Type: `string`
 
-Default: `"ca-issuer"`
-
-==== [[input_namespace]] <<input_namespace,namespace>>
-
-Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-
-Type: `string`
-
-Default: `"keycloak"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -332,12 +316,6 @@ Description: Credentials for the administrator user of the master realm created 
 |n/a
 |yes
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|`"argocd"`
-|no
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -359,19 +337,13 @@ Description: Credentials for the administrator user of the master realm created 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.1"`
+|`"v2.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
-|`"ca-issuer"`
-|no
-
-|[[input_namespace]] <<input_namespace,namespace>>
-|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
-|`string`
-|`"keycloak"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "argocd_project" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "keycloak"
     }
 
     orphaned_resources {
@@ -68,7 +68,7 @@ resource "argocd_application" "operator" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "keycloak"
     }
 
     sync_policy {
@@ -133,7 +133,7 @@ resource "argocd_application" "this" {
 
     destination {
       name      = var.destination_cluster
-      namespace = var.namespace
+      namespace = "keycloak"
     }
 
     sync_policy {
@@ -183,7 +183,7 @@ resource "null_resource" "wait_for_keycloak" {
 data "kubernetes_secret" "admin_credentials" {
   metadata {
     name      = "keycloak-initial-admin"
-    namespace = var.namespace
+    namespace = "keycloak"
   }
   depends_on = [
     resource.null_resource.wait_for_keycloak,

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "argocd_project" "this" {
 
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "keycloak-${var.destination_cluster}" : "keycloak"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
   }
 
   spec {
@@ -45,7 +45,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "argocd_application" "operator" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "keycloak-operator-${var.destination_cluster}" : "keycloak-operator"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "keycloak-operator"
       "cluster"     = var.destination_cluster
@@ -104,7 +104,7 @@ resource "argocd_application" "operator" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "keycloak-${var.destination_cluster}" : "keycloak"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "keycloak"
       "cluster"     = var.destination_cluster

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,9 @@ resource "argocd_application" "operator" {
       repo_url        = "https://github.com/camptocamp/devops-stack-module-keycloak.git"
       path            = "charts/keycloak-operator"
       target_revision = var.target_revision
+      helm {
+        release_name = "keycloak-operator"
+      }
     }
 
     destination {
@@ -123,7 +126,8 @@ resource "argocd_application" "this" {
       path            = "charts/keycloak"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "keycloak"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 

--- a/oidc_bootstrap/README.adoc
+++ b/oidc_bootstrap/README.adoc
@@ -161,11 +161,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_keycloak]] <<provider_keycloak,keycloak>> (>= 4)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -212,7 +212,7 @@ Description: SSL certificate issuer to use. In this module it is used to conditi
 
 Type: `string`
 
-Default: `"ca-issuer"`
+Default: `"selfsigned-issuer"`
 
 ==== [[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 
@@ -302,9 +302,9 @@ Description: Map containing the credentials of each created user.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -348,7 +348,7 @@ Description: Map containing the credentials of each created user.
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. In this module it is used to conditionally add extra arguments to the OIDC configuration.
 |`string`
-|`"ca-issuer"`
+|`"selfsigned-issuer"`
 |no
 
 |[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>

--- a/oidc_bootstrap/locals.tf
+++ b/oidc_bootstrap/locals.tf
@@ -6,7 +6,7 @@ locals {
     api_url       = format("https://keycloak.apps.%s.%s/realms/devops-stack/protocol/openid-connect/userinfo", var.cluster_name, var.base_domain)
     client_id     = "devops-stack-applications"
     client_secret = resource.random_password.client_secret.result
-    oauth2_proxy_extra_args = var.cluster_issuer == "ca-issuer" || var.cluster_issuer == "letsencrypt-staging" ? [
+    oauth2_proxy_extra_args = var.cluster_issuer != "letsencrypt-prod" ? [
       "--insecure-oidc-skip-issuer-verification=true",
       "--ssl-insecure-skip-verify=true",
     ] : []

--- a/oidc_bootstrap/variables.tf
+++ b/oidc_bootstrap/variables.tf
@@ -15,7 +15,7 @@ variable "base_domain" {
 variable "cluster_issuer" {
   description = "SSL certificate issuer to use. In this module it is used to conditionally add extra arguments to the OIDC configuration."
   type        = string
-  default     = "ca-issuer"
+  default     = "selfsigned-issuer"
 }
 
 variable "dependency_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,12 +12,6 @@ variable "base_domain" {
   type        = string
 }
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-  default     = "argocd"
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "target_revision" {
 variable "cluster_issuer" {
   description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files."
   type        = string
-  default     = "ca-issuer"
+  default     = "selfsigned-issuer"
 }
 
 variable "namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,12 +48,6 @@ variable "cluster_issuer" {
   default     = "selfsigned-issuer"
 }
 
-variable "namespace" {
-  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type        = string
-  default     = "keycloak"
-}
-
 variable "helm_values" {
   description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any


### PR DESCRIPTION
## Description of the changes

The main changes of this PR are the following:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the namespace variable**

  We found out that on multiple modules we were referencing resources from other modules using their default namespaces and this was hardcoded. In case someone decided to change the namespace of deployment of a certain application, this could break the way modules work with each other.

  We've decided that in order to avoid undefined behaviors caused by overloading this variable, it would be best to remove it entirely.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

- Change the default cluster issuer to the one that is in fact always created by the cert-manager module.

- In line with the previous change, change the condition to disable the SSL verification on the OIDC to also include the selfsigned-issuer.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `namespace` and `argocd_namespace` variables and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] KinD
- [x] SKS (Exoscale)