### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,19 +28,19 @@ locals {
         }
         hosts = [
           {
-            host = "keycloak.apps.${var.base_domain}"
+            host = "keycloak.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
             path = "/"
           },
           {
-            host = "keycloak.apps.${var.cluster_name}.${var.base_domain}"
+            host = "keycloak.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
             path = "/"
           },
         ]
         tls = [{
           secretName = "keycloak-tls"
           hosts = [
-            "keycloak.apps.${var.base_domain}",
-            "keycloak.apps.${var.cluster_name}.${var.base_domain}"
+            "keycloak.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
+            "keycloak.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
           ]
         }]
       }

--- a/main.tf
+++ b/main.tf
@@ -169,8 +169,8 @@ resource "argocd_application" "this" {
 resource "null_resource" "wait_for_keycloak" {
   provisioner "local-exec" {
     command = <<EOT
-    while [ $(curl -k https://keycloak.apps.${var.cluster_name}.${var.base_domain} -I -s | head -n 1 | cut -d' ' -f2) != '200' ]; do
-      sleep 5 
+    while [ $(curl -k https://keycloak.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain} -I -s | head -n 1 | cut -d' ' -f2) != '200' ]; do
+      sleep 5
     done
     EOT
   }

--- a/oidc_bootstrap/locals.tf
+++ b/oidc_bootstrap/locals.tf
@@ -1,9 +1,9 @@
 locals {
   oidc = {
-    issuer_url    = format("https://keycloak.apps.%s.%s/realms/devops-stack", var.cluster_name, var.base_domain)
-    oauth_url     = format("https://keycloak.apps.%s.%s/realms/devops-stack/protocol/openid-connect/auth", var.cluster_name, var.base_domain)
-    token_url     = format("https://keycloak.apps.%s.%s/realms/devops-stack/protocol/openid-connect/token", var.cluster_name, var.base_domain)
-    api_url       = format("https://keycloak.apps.%s.%s/realms/devops-stack/protocol/openid-connect/userinfo", var.cluster_name, var.base_domain)
+    issuer_url    = format("https://keycloak.%s.%s/realms/devops-stack", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain)
+    oauth_url     = format("https://keycloak.%s.%s/realms/devops-stack/protocol/openid-connect/auth", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain)
+    token_url     = format("https://keycloak.%s.%s/realms/devops-stack/protocol/openid-connect/token", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain)
+    api_url       = format("https://keycloak.%s.%s/realms/devops-stack/protocol/openid-connect/userinfo", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain)
     client_id     = "devops-stack-applications"
     client_secret = resource.random_password.client_secret.result
     oauth2_proxy_extra_args = var.cluster_issuer != "letsencrypt-prod" ? [

--- a/oidc_bootstrap/variables.tf
+++ b/oidc_bootstrap/variables.tf
@@ -12,6 +12,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "cluster_issuer" {
   description = "SSL certificate issuer to use. In this module it is used to conditionally add extra arguments to the OIDC configuration."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [X] No


## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)

Only tested locally.