### PR TITLE
fix: remove legacy ingress annotations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -181,7 +181,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -351,7 +351,7 @@ Description: Credentials for the administrator user of the master realm created 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/locals.tf
+++ b/locals.tf
@@ -22,8 +22,6 @@ locals {
           "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
           "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
           "traefik.ingress.kubernetes.io/router.tls"         = "true"
-          "ingress.kubernetes.io/ssl-redirect"               = "true"
-          "kubernetes.io/ingress.allow-http"                 = "false"
         }
         hosts = [
           {

--- a/oidc_bootstrap/README.adoc
+++ b/oidc_bootstrap/README.adoc
@@ -161,11 +161,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_random]] <<provider_random,random>> (>= 3)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 - [[provider_keycloak]] <<provider_keycloak,keycloak>> (>= 4)
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
+- [[provider_random]] <<provider_random,random>> (>= 3)
 
 === Resources
 
@@ -310,9 +310,9 @@ Description: Map containing the credentials of each created user.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_keycloak]] <<provider_keycloak,keycloak>> |>= 4
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources


### PR DESCRIPTION
## Description of the changes

The SSL redirection is no longer defined by these annotations, I think this is a leftover from ancient code. The HTTP -> HTTPS redirection is handled natively by the Traefik module and is enabled by default (a variable is available to deactivate it if necessary).

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)